### PR TITLE
Remove obsolete props, fix deselect related bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 ## <next>
 * Item shouldn't get deselected when clicking on the header. This is now fixed.
+* Removed `defaultExpandedKeys`, `defaultSelectedKeys` and `defaultCheckedKeys` props. You can achieve the same result with `expandedKeys`, `selectedKeys` and `checkedKeys`.
 
 ## 1.6.0
 * Added expand all toggle and `showExpandAll`, `headerRight`  & `title` props

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 ## <next>
+* Item shouldn't get deselected when clicking on the header. This is now fixed.
 
 ## 1.6.0
 * Added expand all toggle and `showExpandAll`, `headerRight`  & `title` props

--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@ Also you need to configure sass loader, since all the styles are in sass format.
 |                          |                  |  chevron                                 | nodes as chevrons                        |
 |                          |                  |  carets                                  | nodes as carets                          |
 |                          |                  |  arrow                                   | nodes as arrows                          |
-| defaultExpandedKeys      | Array            |  []                                      | Array of item ids to expand by default   |
-| defaultSelectedKeys      | Array            |  []                                      | Array of item ids selected by default    |
-| defaultCheckedKeys       | Array            |  []                                      | Array of item ids checked by default     |
 | onExpand                 | Function         |  () => {}                                | Handling the node expand. Takes 'expandedKeys' as parameter ```jsx onExpand(expKeys) { console.log(expKeys, arguments); }                                ```|
 | onSelect                 | Function         |  () => {}                                | Handling the item select. Takes 'selectedKeys' and 'info' (event object to get node)as parameter ```jsx onSelect(selKeys, info) { console.log(selKeys, info); }                        ```|
 | onCheck                  | Function         |  () => {}                                | Handling the item checked                |

--- a/src/tree.component.jsx
+++ b/src/tree.component.jsx
@@ -12,9 +12,6 @@ export default class OCTreeView extends React.PureComponent {
     treeId: PropTypes.string,
     className: PropTypes.string,
     iconClass: PropTypes.string,
-    defaultExpandedKeys: PropTypes.arrayOf(PropTypes.string),
-    defaultSelectedKeys: PropTypes.arrayOf(PropTypes.string),
-    defaultCheckedKeys: PropTypes.arrayOf(PropTypes.string),
     onExpand: PropTypes.func,
     onSelect: PropTypes.func,
     onCheck: PropTypes.func,
@@ -44,9 +41,6 @@ export default class OCTreeView extends React.PureComponent {
   static defaultProps = {
     treeId: 'defaultTree',
     iconClass: 'carets',
-    defaultExpandedKeys: [],
-    defaultSelectedKeys: [],
-    defaultCheckedKeys: [],
     onExpand: undefined,
     onSelect: undefined,
     onCheck: undefined,
@@ -77,7 +71,7 @@ export default class OCTreeView extends React.PureComponent {
   constructor(props) {
     super();
     const expandedKeys = props.defaultExpandAll ?
-      this.getAllParentIds(props.treeData, props) : props.defaultExpandedKeys;
+      this.getAllParentIds(props.treeData, props) : props.expandedKeys;
 
     this.state = {
       expandedKeys,
@@ -301,9 +295,8 @@ export default class OCTreeView extends React.PureComponent {
   render() {
     const nodes = this.renderNodes();
     const {
-      treeId, className, defaultExpandedKeys, defaultSelectedKeys, defaultCheckedKeys, checkedKeys,
-      onExpand, onSelect, onCheck, showLine, showIcon, checkable, selectable,
-      draggable, disabled, selectedKeys, showExpandAll, title, headerRight,
+      treeId, className, checkedKeys, onExpand, onSelect, onCheck, showLine, showIcon,
+      checkable, selectable, draggable, disabled, selectedKeys, showExpandAll, title, headerRight,
     } = this.props;
     const clsName = className ? `${className} oc-react-tree` : 'oc-react-tree';
     const expandAllClsName = this.isAllExpanded() ? 'expand-all' : '';
@@ -329,9 +322,6 @@ export default class OCTreeView extends React.PureComponent {
         <Tree
           id={treeId}
           className={className}
-          defaultExpandedKeys={defaultExpandedKeys}
-          defaultSelectedKeys={defaultSelectedKeys}
-          defaultCheckedKeys={defaultCheckedKeys}
           checkedKeys={checkedKeys}
           selectedKeys={selectedKeys}
           expandedKeys={this.state.expandedKeys}

--- a/src/tree.component.jsx
+++ b/src/tree.component.jsx
@@ -95,7 +95,7 @@ export default class OCTreeView extends React.PureComponent {
   onContainerClick = (e) => {
     const { onSelect, deselectOnContainerClick } = this.props;
     // clicking outside item
-    if (deselectOnContainerClick && e.target.tagName !== 'SPAN') {
+    if (deselectOnContainerClick && e.target.tagName !== 'SPAN' && !this.header.contains(e.target)) {
       onSelect([]);
     }
   };
@@ -313,7 +313,12 @@ export default class OCTreeView extends React.PureComponent {
       <div id="tree-view-container" className={clsName} onClick={this.onContainerClick}>
 
         {(showExpandAll || title || headerRight) &&
-        <header className="title-container">
+        <header
+          className="title-container"
+          ref={(el) => {
+            this.header = el;
+          }}
+        >
           {showExpandAll &&
           <button onClick={this.onExpandAllClick} className={`expand-all-toggle ${expandAllClsName}`} />}
           {title && <h2>{title}</h2>}


### PR DESCRIPTION
* Item shouldn't get deselected when clicking on the header. This is now fixed.
* Removed `defaultExpandedKeys`, `defaultSelectedKeys` and `defaultCheckedKeys` props. You can achieve the same result with `expandedKeys`, `selectedKeys` and `checkedKeys`.