### PR TITLE
Add scrollbar, fix onExpand logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 ## <next>
+* Added `@opuscapita/react-perfect-scrollbar` around tree
+* Made some changes on how nodes are expanded. Now it's not necessary to provide external `onExpand` callback in most of the cases.
 
 ## 2.0.1
 * Hotfix: `expandedKeys` default value from `[]` to undefined.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Also you need to configure sass loader, since all the styles are in sass format.
 | dataLookUpValue          | String           | 'parent'                                 | Representative value of data item.       |
 | dataLookUpChildren       | String           | 'children'                               | Data item property to identifiy subitems |
 | checkedKeys              | Array            | []                                       | Array of checked items (ids) |
-| expandedKeys             | Array            | undefined                                | Array of expanded items (ids) |
+| expandedKeys             | Array            | []                                       | Array of expanded items (ids) |
 | selectedKeys             | Array            | []                                       | Array of selected items (ids) |
 | deselectOnContainerClick | Boolean          | true                                     | Deselects all selected keys when not clicking on any particular item |
 | showExpandAll            | Boolean          | false                                    | Show expand all toggle |

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
   },
   "dependencies": {
     "@opuscapita/oc-cm-common-styles": "2.2.0",
+    "@opuscapita/react-perfect-scrollbar": "3.0.4",
     "rc-tree": "1.14.8"
   },
   "repository": {

--- a/src/oc-tree-styles.scss
+++ b/src/oc-tree-styles.scss
@@ -88,147 +88,153 @@
   }
 }
 
-.rc-tree {
-  .rc-tree-treenode-disabled {
-    > span:not(.rc-tree-switcher) {
-      cursor: default;
-      color: inherit;
-    }
+.oc-react-tree {
+
+  .oc-scrollbar-container {
+    border: 1px solid $oc-color-gray;
+    padding: 1rem;
   }
-}
 
-.rc-tree {
-  $checkbox-width: 1.6rem;
-  padding: 0;
-
-  li {
-    &.rc-tree-treenode-checkbox-checked > span > span {
-      .tree-checkbox:before {
-        content: "\f00c"; // check
-      }
-    }
-    &.rc-tree-treenode-checkbox-indeterminate > span > span {
-      .tree-checkbox:before {
-        content: "\f068" // minus
+  .rc-tree {
+    .rc-tree-treenode-disabled {
+      > span:not(.rc-tree-switcher) {
+        cursor: default;
+        color: inherit;
       }
     }
 
-    .rc-tree-node-content-wrapper {
-      padding: 0;
-      &.draggable {
-        &:hover {
-          &:after {
-            font-family: "FontAwesome";
-            content: "\f07d"; // fa-arrows-v - vertical arrows
-            margin-left: 20px;
-            padding-right: 10px;
-            color: $oc-color-primary-azure;
+    $checkbox-width: 1.6rem;
+    padding: 0;
+
+    li {
+      &.rc-tree-treenode-checkbox-checked > span > span {
+        .tree-checkbox:before {
+          content: "\f00c"; // check
+        }
+      }
+      &.rc-tree-treenode-checkbox-indeterminate > span > span {
+        .tree-checkbox:before {
+          content: "\f068" // minus
+        }
+      }
+
+      .rc-tree-node-content-wrapper {
+        padding: 0;
+        &.draggable {
+          &:hover {
+            &:after {
+              font-family: "FontAwesome";
+              content: "\f07d"; // fa-arrows-v - vertical arrows
+              margin-left: 20px;
+              padding-right: 10px;
+              color: $oc-color-primary-azure;
+            }
           }
+        }
+      }
+
+      &.drag-over {
+        > .draggable {
+          background: $oc-color-primary-orange;
+          border: none;
+        }
+      }
+      &.drag-over-gap-bottom {
+        > .draggable {
+          border-bottom: 2px solid $oc-color-primary-orange;
+        }
+      }
+      &.drag-over-gap-top {
+        > .draggable {
+          border-top: 2px solid $oc-color-primary-orange;
         }
       }
     }
 
-    &.drag-over {
-      > .draggable {
-        background: $oc-color-primary-orange;
-        border: none;
+    .tree-checkbox {
+      border: 1px solid $oc-color-gray;
+      height: $checkbox-width;
+      width: $checkbox-width;
+      cursor: pointer;
+      position: relative;
+      font-family: "FontAwesome";
+      font-size: 12px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      &.disabled {
+        background-color: $oc-color-select-hover;
+        cursor: default;
       }
     }
-    &.drag-over-gap-bottom {
-      > .draggable {
-        border-bottom: 2px solid $oc-color-primary-orange;
-      }
-    }
-    &.drag-over-gap-top {
-      > .draggable {
-        border-top: 2px solid $oc-color-primary-orange;
-      }
-    }
-  }
 
-  .tree-checkbox {
-    border: 1px solid $oc-color-gray;
-    height: $checkbox-width;
-    width: $checkbox-width;
-    cursor: pointer;
-    position: relative;
-    font-family: "FontAwesome";
-    font-size: 12px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    &.disabled {
-      background-color: $oc-color-select-hover;
+    .rc-tree-node-selected {
+      background-color: transparent;
+      border: none;
+      .rc-tree-title {
+        border: none;
+        background-color: $oc-color-site-background;
+        opacity: 1;
+        display: inline-block;
+      }
+    }
+
+    > li:first-child {
+      margin-top: 0;
+    }
+    li {
+      margin: 3px 0;
+      span.rc-tree-checkbox {
+        display: none;
+      }
+    }
+    .rc-tree-title {
+      padding: 0 5px;
+    }
+    .rc-tree-iconEle.rc-tree-icon__customize {
       cursor: default;
     }
   }
 
-  .rc-tree-node-selected {
-    background-color: transparent;
-    border: none;
-    .rc-tree-title {
+  .title-container {
+    display: flex;
+    align-items: center;
+    height: 40px;
+    h2 {
+      font-size: 1.6rem;
+      font-weight: 400;
+      margin: 0;
+    }
+    .header-right {
+      margin-left: auto;
+    }
+    .expand-all-toggle {
+      background: none;
       border: none;
-      background-color: $oc-color-site-background;
-      opacity: 1;
-      display: inline-block;
-    }
-  }
-
-  > li:first-child {
-    margin-top: 0;
-  }
-  li {
-    margin: 3px 0;
-    span.rc-tree-checkbox {
-      display: none;
-    }
-  }
-  .rc-tree-title {
-    padding: 0 5px;
-  }
-  .rc-tree-iconEle.rc-tree-icon__customize {
-    cursor: default;
-  }
-}
-
-.title-container {
-  display: flex;
-  align-items: center;
-  height: 40px;
-  h2 {
-    font-size: 1.6rem;
-    font-weight: 400;
-    margin: 0;
-  }
-  .header-right {
-    margin-left: auto;
-  }
-  .expand-all-toggle {
-    background: none;
-    border: none;
-    position: relative;
-    height: 20px;
-    width: 20px;
-    margin-left: 3px;
-    &:focus {
-      box-shadow: none;
-    }
-    &:before {
-      position: absolute;
-      font-family: "FontAwesome";
-      font-size: 18px;
-      top: 0;
-      left: 0;
-    }
-
-    &.expand-all {
-      &:before {
-        content: "\f0d7"; // caret-down
-        left: -2px;
+      position: relative;
+      height: 20px;
+      width: 20px;
+      margin-left: 3px;
+      &:focus {
+        box-shadow: none;
       }
-    }
-    &:before {
-      content: "\f0da"; // caret-right
+      &:before {
+        position: absolute;
+        font-family: "FontAwesome";
+        font-size: 18px;
+        top: 0;
+        left: 0;
+      }
+
+      &.expand-all {
+        &:before {
+          content: "\f0d7"; // caret-down
+          left: -2px;
+        }
+      }
+      &:before {
+        content: "\f0da"; // caret-right
+      }
     }
   }
 }

--- a/src/tree.component.jsx
+++ b/src/tree.component.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Tree, { TreeNode } from 'rc-tree';
+import PerfectScrollBar from '@opuscapita/react-perfect-scrollbar';
 import 'rc-tree/assets/index.css';
 
 // Override defaults rc-tree styles
@@ -60,7 +61,7 @@ export default class OCTreeView extends React.PureComponent {
     treeData: [],
     checkedKeys: [],
     selectedKeys: [],
-    expandedKeys: undefined,
+    expandedKeys: [],
     className: '',
     deselectOnContainerClick: true,
     showExpandAll: false,
@@ -94,6 +95,13 @@ export default class OCTreeView extends React.PureComponent {
     }
   };
 
+  onExpand = (expandedKeys) => {
+    const { onExpand } = this.props;
+    this.setState({ expandedKeys }, () => {
+      if (onExpand) onExpand(this.state.expandedKeys);
+    });
+  };
+
   onDragDrop = (e) => {
     const { onDragDrop, isDragDropLegal, treeData } = this.props;
     if (!onDragDrop) throw new TypeError('onDragDrop callback is not defined');
@@ -112,6 +120,7 @@ export default class OCTreeView extends React.PureComponent {
       if (onExpand) onExpand(this.state.expandedKeys);
     });
   };
+
   /**
    * Returns updated tree after Drag n' drop event
    * @param dragItem - dragged item
@@ -184,6 +193,7 @@ export default class OCTreeView extends React.PureComponent {
     }
     return found;
   };
+
 
   /**
    * Returns all parent IDs in the tree
@@ -295,8 +305,8 @@ export default class OCTreeView extends React.PureComponent {
   render() {
     const nodes = this.renderNodes();
     const {
-      treeId, className, checkedKeys, onExpand, onSelect, onCheck, showLine, showIcon,
-      checkable, selectable, draggable, disabled, selectedKeys, showExpandAll, title, headerRight,
+      treeId, className, checkedKeys, onSelect, onCheck, showLine, showIcon, checkable, selectable,
+      draggable, disabled, selectedKeys, showExpandAll, title, headerRight,
     } = this.props;
     const clsName = className ? `${className} oc-react-tree` : 'oc-react-tree';
     const expandAllClsName = this.isAllExpanded() ? 'expand-all' : '';
@@ -317,27 +327,28 @@ export default class OCTreeView extends React.PureComponent {
           {title && <h2>{title}</h2>}
           {headerRight && <div className="header-right">{headerRight}</div>}
         </header>}
-
         {!!nodes.length &&
-        <Tree
-          id={treeId}
-          className={className}
-          checkedKeys={checkedKeys}
-          selectedKeys={selectedKeys}
-          expandedKeys={this.state.expandedKeys}
-          onExpand={onExpand}
-          onSelect={onSelect}
-          onCheck={onCheck}
-          onDrop={this.onDragDrop}
-          checkable={checkable}
-          selectable={selectable}
-          draggable={draggable}
-          showLine={showLine}
-          showIcon={showIcon}
-          disabled={disabled}
-        >
-          {nodes}
-        </Tree>
+        <PerfectScrollBar>
+          <Tree
+            id={treeId}
+            className={className}
+            checkedKeys={checkedKeys}
+            selectedKeys={selectedKeys}
+            expandedKeys={this.state.expandedKeys}
+            onExpand={this.onExpand}
+            onSelect={onSelect}
+            onCheck={onCheck}
+            onDrop={this.onDragDrop}
+            checkable={checkable}
+            selectable={selectable}
+            draggable={draggable}
+            showLine={showLine}
+            showIcon={showIcon}
+            disabled={disabled}
+          >
+            {nodes}
+          </Tree>
+        </PerfectScrollBar>
         }
       </div>
     );


### PR DESCRIPTION
* Added `@opuscapita/react-perfect-scrollbar` around tree
* Made some changes on how nodes are expanded. Now it's not necessary to provide external `onExpand` callback in most of the cases.
* Added gray border around tree area