### PR TITLE
Manual/automatic node expansion 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
+* `handleExpandedKeysManually` and `defaultExpandAll` props
 
 ## 2.2.0
 * Remove redundant `showLine` prop

--- a/README.md
+++ b/README.md
@@ -23,39 +23,41 @@ Also you need to configure sass loader, since all the styles are in sass format.
 
 ### API
 | Prop name                | Type             | Default                                  | Description                              |
-| ------------------------ | ---------------- | ---------------------------------------- | ---------------------------------------- |
-| treeId                   | string           |  defaultTree                             | Tree identifier                          |
-| className                | string           |  ''                                      | Tree container custom class for styling  |
-| iconClass                | string           |  'carets'                                | FontAwesome content based indicators:    |
-|                          |                  |  chevron                                 | nodes as chevrons                        |
-|                          |                  |  carets                                  | nodes as carets                          |
-|                          |                  |  arrow                                   | nodes as arrows                          |
-| onExpand                 | Function         |  () => {}                                | Handling the node expand. Takes 'expandedKeys' as parameter ```jsx onExpand(expKeys) { console.log(expKeys, arguments); }                                ```|
-| onSelect                 | Function         |  () => {}                                | Handling the item select. Takes 'selectedKeys' and 'info' (event object to get node)as parameter ```jsx onSelect(selKeys, info) { console.log(selKeys, info); }                        ```|
-| onCheck                  | Function         |  () => {}                                | Handling the item checked                |
-| onDragDrop               | Function         |  () => {}                                | Fires when item is dragged and dropped   |
-| onOrderButtonClick       | Function         |  undefined                               | Fires when ordering arrows are clicked   |
-| isDragDropLegal          | Function         |  undefined                               | This callback is executed before completing drag n' drop action. Function should return a bool   |
-| showIcon                 | Boolean          |  false                                   | Whether show or hide node guide lines    |
-| checkable                | Boolean          |  false                                   | Whether show or hide checkboxes from tree|
-| selectable               | Boolean          |  false                                   | Whether item can be selected.            |
-| disabled                 | Boolean          |  false                                   | Disables all node items checkboxes.      |
-| draggable                | Boolean          |  false                                   | Whether item can be dragged around.      |
-| defaultExpandAll         | Boolean          |  false                                   | Expand all nodes by default.             |
-|                          |                  |                                          | Note! For better performance do not      |
-|                          |                  |                                          | enable this for large dataSets.          |
-| treeData                 | Array            | []                                       | Array of node objects.                   |
-| dataLookUpKey            | String           | 'key'                                    | Unique identifier of data item.          |
-| dataLookUpValue          | String           | 'parent'                                 | Representative value of data item.       |
-| dataLookUpChildren       | String           | 'children'                               | Data item property to identifiy subitems |
-| checkedKeys              | Array            | []                                       | Array of checked items (ids) |
-| expandedKeys             | Array            | []                                       | Array of expanded items (ids) |
-| selectedKeys             | Array            | []                                       | Array of selected items (ids) |
-| deselectOnContainerClick | Boolean          | true                                     | Deselects all selected keys when not clicking on any particular item |
-| showExpandAll            | Boolean          | false                                    | Show expand all toggle |
-| title                    | String           | undefined                                | Tree title |
-| headerRight              | Node             | undefined                                | Content displayed on the right side of the header |
-| showOrderingArrows       | Boolean          | false                                    | Shows arrows for reordering the tree items. (if you don't want to use (flawed) drag n' drop)
+| -------------------------- | ---------------- | ---------------------------------------- | ---------------------------------------- |
+| treeId                     | string           |  defaultTree                             | Tree identifier                          |
+| className                  | string           |  ''                                      | Tree container custom class for styling  |
+| iconClass                  | string           |  'carets'                                | FontAwesome content based indicators:    |
+|                            |                  |  chevron                                 | nodes as chevrons                        |
+|                            |                  |  carets                                  | nodes as carets                          |
+|                            |                  |  arrow                                   | nodes as arrows                          |
+| onExpand                   | Function         |  () => {}                                | Handling the node expand. Takes 'expandedKeys' as parameter ```jsx onExpand(expKeys) { console.log(expKeys, arguments); }                                ```|
+| onSelect                   | Function         |  () => {}                                | Handling the item select. Takes 'selectedKeys' and 'info' (event object to get node)as parameter ```jsx onSelect(selKeys, info) { console.log(selKeys, info); }                        ```|
+| onCheck                    | Function         |  () => {}                                | Handling the item checked                |
+| onDragDrop                 | Function         |  () => {}                                | Fires when item is dragged and dropped   |
+| onOrderButtonClick         | Function         |  undefined                               | Fires when ordering arrows are clicked   |
+| isDragDropLegal            | Function         |  undefined                               | This callback is executed before completing drag n' drop action. Function should return a bool   |
+| showIcon                   | Boolean          |  false                                   | Whether show or hide node guide lines    |
+| checkable                  | Boolean          |  false                                   | Whether show or hide checkboxes from tree|
+| selectable                 | Boolean          |  false                                   | Whether item can be selected.            |
+| disabled                   | Boolean          |  false                                   | Disables all node items checkboxes.      |
+| draggable                  | Boolean          |  false                                   | Whether item can be dragged around.      |
+| defaultExpandAll           | Boolean          |  false                                   | Expand all nodes by default.             |
+|                            |                  |                                          | Note! For better performance do not      |
+|                            |                  |                                          | enable this for large dataSets.          |
+| treeData                   | Array            | []                                       | Array of node objects.                   |
+| dataLookUpKey              | String           | 'key'                                    | Unique identifier of data item.          |
+| dataLookUpValue            | String           | 'parent'                                 | Representative value of data item.       |
+| dataLookUpChildren         | String           | 'children'                               | Data item property to identifiy subitems |
+| checkedKeys                | Array            | []                                       | Array of checked items (ids) |
+| expandedKeys               | Array            | []                                       | Array of expanded items (ids) |
+| defaultExpandedKeys        | Array            | []                                       | Array of items that are expanded by default (ids). Use expandedKeys instead, if you're using 'handleExpandedKeysManually' |
+| selectedKeys               | Array            | []                                       | Array of selected items (ids) |
+| deselectOnContainerClick   | Boolean          | true                                     | Deselects all selected keys when not clicking on any particular item |
+| showExpandAll              | Boolean          | false                                    | Show expand all toggle |
+| title                      | String           | undefined                                | Tree title |
+| headerRight                | Node             | undefined                                | Content displayed on the right side of the header |
+| showOrderingArrows         | Boolean          | false                                    | Shows arrows for reordering the tree items. (if you don't want to use (flawed) drag n' drop) |
+| handleExpandedKeysManually | Boolean          | false                                    | Use this, if you want a full control of expanded keys. Don't use this, if you want rc-tree to handle node expansion automatically |
 
 ### Code example
 ```jsx

--- a/src/tree.component.jsx
+++ b/src/tree.component.jsx
@@ -34,6 +34,8 @@ export default class OCTreeView extends React.PureComponent {
     checkedKeys: PropTypes.arrayOf(PropTypes.string),
     selectedKeys: PropTypes.arrayOf(PropTypes.string),
     expandedKeys: PropTypes.arrayOf(PropTypes.string),
+    handleExpandedKeysManually: PropTypes.bool,
+    defaultExpandedKeys: PropTypes.arrayOf(PropTypes.string),
     deselectOnContainerClick: PropTypes.bool,
     showExpandAll: PropTypes.bool,
     title: PropTypes.string,
@@ -64,12 +66,14 @@ export default class OCTreeView extends React.PureComponent {
     checkedKeys: [],
     selectedKeys: [],
     expandedKeys: [],
+    defaultExpandedKeys: [],
     className: '',
     deselectOnContainerClick: true,
     showExpandAll: false,
     title: undefined,
     headerRight: undefined,
     showOrderingArrows: false,
+    handleExpandedKeysManually: false,
   };
 
   constructor(props) {
@@ -83,7 +87,8 @@ export default class OCTreeView extends React.PureComponent {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.expandedKeys !== this.props.expandedKeys) {
+    if (nextProps.handleExpandedKeysManually &&
+      (nextProps.expandedKeys !== this.props.expandedKeys)) {
       this.setState({
         expandedKeys: nextProps.expandedKeys,
       });
@@ -102,7 +107,8 @@ export default class OCTreeView extends React.PureComponent {
   };
 
   onExpand = (expandedKeys) => {
-    const { onExpand } = this.props;
+    const { onExpand, handleExpandedKeysManually } = this.props;
+    if (!handleExpandedKeysManually) return;
     this.setState({ expandedKeys }, () => {
       if (onExpand) onExpand(this.state.expandedKeys);
     });
@@ -321,13 +327,18 @@ export default class OCTreeView extends React.PureComponent {
 
   render() {
     const nodes = this.renderNodes();
+    const resolvedProps = {};
     const {
       treeId, className, checkedKeys, onSelect, onCheck, showIcon, checkable, selectable,
       draggable, disabled, selectedKeys, showExpandAll, title, headerRight, showOrderingArrows,
-      onOrderButtonClick,
+      onOrderButtonClick, defaultExpandedKeys, handleExpandedKeysManually,
     } = this.props;
     const clsName = className ? `${className} oc-react-tree` : 'oc-react-tree';
     const expandAllClsName = this.isAllExpanded() ? 'expand-all' : '';
+
+    // We don't pass expandedKeys to rc-tree unless we want to handle expandedKeys
+    // by ourselves
+    if (handleExpandedKeysManually) resolvedProps.expandedKeys = this.state.expandedKeys;
 
     return (
       // eslint-disable-next-line
@@ -370,7 +381,7 @@ export default class OCTreeView extends React.PureComponent {
               className={className}
               checkedKeys={checkedKeys}
               selectedKeys={selectedKeys}
-              expandedKeys={this.state.expandedKeys}
+              defaultExpandedKeys={defaultExpandedKeys}
               onExpand={this.onExpand}
               onSelect={onSelect}
               onCheck={onCheck}
@@ -381,6 +392,7 @@ export default class OCTreeView extends React.PureComponent {
               showLine={false}
               showIcon={showIcon}
               disabled={disabled}
+              {...resolvedProps}
             >
               {nodes}
             </Tree>


### PR DESCRIPTION
- `handleExpandedKeysManually` prop: One can now choose between automatic node expansion (rc-tree takes care of the expandedKeys array) and manual node expansion (you can add/remove expanded keys manually)
- `defaultExpandedKeys`prop: these keys are expanded by default (when not using `handleExpandedKeysManually`